### PR TITLE
typo: replace require with import and export BrowserWindow

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A node module to help build	browser like windows in electron.
 ### First, create BrowserLikeWindow in [Main](https://electronjs.org/docs/glossary#main-process) process
 
 ```javascript
-const BrowserLikeWindow = require('electron-as-browser');
+import BrowserLikeWindow from 'electron-as-browser';
 
 let browser;
 
@@ -54,7 +54,7 @@ To make the control interface works, there are two steps:
 For react users, there is a custom hook `useConnect` to help you setup ipc channels.
 
 ```javascript
-const useConnect = require('electron-as-browser/useConnect');
+import useConnect from 'electron-as-browser/useConnect';
 
 const ControlPanel = () => {
   const { tabs, tabIDs, activeID } = useConnect();

--- a/control.js
+++ b/control.js
@@ -1,4 +1,4 @@
-const { ipcRenderer } = require('electron');
+import { ipcRenderer } from 'electron';
 
 // Used in Renderer process
 

--- a/example/main.js
+++ b/example/main.js
@@ -1,6 +1,6 @@
-const { app } = require('electron');
-const fileUrl = require('file-url');
-const BrowserLikeWindow = require('../index');
+import { app } from 'electron';
+import fileUrl from 'file-url';
+import BrowserLikeWindow from '../index';
 
 let browser;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import type { BrowserWindowConstructorOptions, WebPreferences, Rectangle } from 'electron';
+import type { BrowserWindow, BrowserWindowConstructorOptions, WebPreferences, Rectangle } from 'electron';
 import type { EventEmitter } from 'events';
 
 type TabID = number;
@@ -33,6 +33,8 @@ interface BrowserLikeWindowOptions {
 }
 
 export default class BrowserLikeWindow extends EventEmitter {
+    win: BrowserWindow;
+
     constructor(options: BrowserLikeWindowOptions);
     getControlBounds(): Rectangle;
     setContentBounds(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,7 @@ interface BrowserLikeWindowOptions {
     debug?: boolean;
 }
 
-class BrowserLikeWindow extends EventEmitter {
+export default class BrowserLikeWindow extends EventEmitter {
     constructor(options: BrowserLikeWindowOptions);
     getControlBounds(): Rectangle;
     setContentBounds(): void;
@@ -59,5 +59,3 @@ class BrowserLikeWindow extends EventEmitter {
     switchTab(viewId: TabID): void;
     destroyView(viewId: TabID): void;
 }
-
-export = BrowserLikeWindow;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
-const { BrowserWindow, BrowserView, ipcMain } = require('electron');
-const EventEmitter = require('events');
-const log = require('electron-log');
+import { BrowserWindow, BrowserView, ipcMain } from 'electron';
+import EventEmitter from 'events';
+import log from 'electron-log';
 
 log.transports.file.level = false;
 log.transports.console.level = false;
@@ -49,7 +49,7 @@ log.transports.console.level = false;
  * @param {function} [options.onNewWindow] - custom webContents `new-window` event handler
  * @param {boolean} [options.debug] - toggle debug
  */
-class BrowserLikeWindow extends EventEmitter {
+export default class BrowserLikeWindow extends EventEmitter {
   constructor(options) {
     super();
 
@@ -451,5 +451,3 @@ class BrowserLikeWindow extends EventEmitter {
     }
   }
 }
-
-module.exports = BrowserLikeWindow;

--- a/useConnect.js
+++ b/useConnect.js
@@ -1,5 +1,5 @@
-const { ipcRenderer } = require('electron');
-const { useEffect, useState } = require('react');
+import { ipcRenderer } from 'electron';
+import { useEffect, useState } from 'react';
 
 // Used in Renderer process
 


### PR DESCRIPTION
1. use import instead of require to make eslint happy.
2. sometime we want to change tab attribute directly by method, therefore export it.